### PR TITLE
Add ChatGPT page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A simulation of a crypto checkout backend with webhook support, built with FastA
 - POST `/api/webhook` - Handles payment status updates
 - SQLite database for transaction storage
 - Simple Next.js frontend for demonstration
+- ChatGPT integration with an interactive `/chat` page
 
 ## Getting Started
 
@@ -39,6 +40,7 @@ A simulation of a crypto checkout backend with webhook support, built with FastA
 1. Navigate to `frontend/`
 2. Install dependencies: `npm install`
 3. Run the development server: `npm run dev`
+4. Set the `OPENAI_API_KEY` environment variable to enable the chat page
 
 
 #### Things to Improve

--- a/frontend/src/app/api/chatgpt/route.ts
+++ b/frontend/src/app/api/chatgpt/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { messages } = await req.json();
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'OPENAI_API_KEY not configured' }, { status: 500 });
+  }
+
+  const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages,
+    }),
+  });
+
+  if (!resp.ok) {
+    const err = await resp.text();
+    return NextResponse.json({ error: err }, { status: resp.status });
+  }
+
+  const data = await resp.json();
+  return NextResponse.json(data);
+}

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+import { useState } from 'react';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const newMessages = [...messages, { role: 'user', content: input }];
+    setMessages(newMessages);
+    setInput('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/chatgpt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: newMessages }),
+      });
+      const data = await res.json();
+      const reply = data.choices?.[0]?.message?.content || 'No response';
+      setMessages([...newMessages, { role: 'assistant', content: reply }]);
+    } catch (err) {
+      setMessages([...newMessages, { role: 'assistant', content: 'Error fetching response' }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center p-4">
+      <div className="w-full max-w-xl bg-white rounded-lg shadow p-4 flex flex-col flex-1">
+        <h1 className="text-xl font-semibold mb-4">ChatGPT Assistant</h1>
+        <div className="flex-1 overflow-y-auto mb-4 space-y-2">
+          {messages.map((m, idx) => (
+            <div
+              key={idx}
+              className={`p-3 rounded-lg max-w-prose ${m.role === 'user' ? 'bg-blue-100 self-end' : 'bg-gray-100'}`}
+            >
+              {m.content}
+            </div>
+          ))}
+          {loading && <div className="p-3 bg-gray-100 rounded-lg">Thinking...</div>}
+        </div>
+        <div className="flex gap-2">
+          <input
+            className="flex-1 border rounded px-3 py-2 text-black"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
+            placeholder="Type your message"
+          />
+          <button
+            onClick={sendMessage}
+            className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+            disabled={loading}
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate ChatGPT API with an API route and chat page
- document the new `/chat` page and environment variable usage

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e729b02f48320b7b78b23aeccc32d